### PR TITLE
Adding a Shebang and clarifying Python Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dankon al wikimedia por la libraj bildoj por la kartoj.
 ## Krei la kartaron
 
 ```
-python genkartoj.py
+python3 genkartoj.py
 ```
 
 Kaj poste kompili en LaTeX. Mi uzis texlive sub Manjaro Linux.

--- a/genkartoj.py
+++ b/genkartoj.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import json, math, random
 
 pagxekajxo = """\n\n \\pagebreak \n\n"""


### PR DESCRIPTION
when running on systems, where "python" defaults to python 2, the script will exit with an error. That way it's more obvious which Python version should be used.